### PR TITLE
Ajoute une action github pour déployer sur scalingo

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           echo BEARER_TOKEN=$(curl -H "Accept: application/json" -H "Content-Type: application/json" \
-            -u ":${{ secrets.SCALINGO_BEARER_TOKEN }}" \
+            -u ":${{ secrets.SCALINGO_AUTHENTICATION_TOKEN }}" \
             -X POST https://auth.scalingo.com/v1/tokens/exchange | jq .token) >> $GITHUB_OUTPUT
       - name: Trigger a deployment on scalingo
         shell: bash

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -37,6 +37,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build]
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Trigger a deployment on scalingo
           shell: bash

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,10 +1,18 @@
-name: Node.js CI
+name: Node.js CI / Scalingo CD
 
 on:
   push:
     branches: ["master"]
   pull_request:
     branches: ["master"]
+  schedule:
+    # https://crontab.guru/#0_2_*_*_*
+    - cron: "0 2 * * *"
+
+env:
+  SCALINGO_API_URL: api.osc-fr1.scalingo.com
+  SCALINGO_APP: annuaire-etablissements-publics
+  SOURCE_ARCHIVE: https://github.com/BaseAdresseNationale/annuaire-api/archive/master.tar.gz
 
 jobs:
   build:
@@ -25,3 +33,20 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test
+  
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Trigger a deployment on scalingo
+          shell: bash
+          run: |
+            curl -H "Accept: application/json" -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.SCALINGO_BEARER_TOKEN }}" \
+              -X POST https://${{ SCALINGO_API_URL }}/v1/apps/${{ SCALINGO_APP }}/deployments -d \
+              '{
+                "deployment": {
+                  "git_ref": "master",
+                  "source_url": "${{ SOURCE_ARCHIVE }}"
+                }
+              }'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,15 +39,22 @@ jobs:
     needs: [build]
     if: github.ref == 'refs/heads/master'
     steps:
+      - name: Fetch a bearer token
+        id: fetch_bearer_token
+        shell: bash
+        run: |
+          echo BEARER_TOKEN=$(curl -H "Accept: application/json" -H "Content-Type: application/json" \
+            -u ":${{ secrets.SCALINGO_BEARER_TOKEN }}" \
+            -X POST https://auth.scalingo.com/v1/tokens/exchange | jq .token) >> $GITHUB_OUTPUT
       - name: Trigger a deployment on scalingo
-          shell: bash
-          run: |
-            curl -H "Accept: application/json" -H "Content-Type: application/json" \
-              -H "Authorization: Bearer ${{ secrets.SCALINGO_BEARER_TOKEN }}" \
-              -X POST https://${{ SCALINGO_API_URL }}/v1/apps/${{ SCALINGO_APP }}/deployments -d \
-              '{
-                "deployment": {
-                  "git_ref": "master",
-                  "source_url": "${{ SOURCE_ARCHIVE }}"
-                }
-              }'
+        shell: bash
+        run: |
+          curl -H "Accept: application/json" -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ steps.fetch_bearer_token.outputs.BEARER_TOKEN }}" \
+            -X POST https://${{ env.SCALINGO_API_URL }}/v1/apps/${{ env.SCALINGO_APP }}/deployments -d \
+            '{
+              "deployment": {
+                "git_ref": "master",
+                "source_url": "${{ env.SOURCE_ARCHIVE }}"
+              }
+            }'


### PR DESCRIPTION
## Notes sur la PR

Lors du build de l'application annuaire-api des données sont téléchargées depuis plusieurs sources différentes (notamment https://lecomarquage.service-public.fr/donnees_locales_v4/all_latest.tar.bz2).

Ces données sont mises à jour de manière quotidienne, mais le build de l'application sur scalingo ne se fait que lors d'une modification de la branche master, ce qui fait que l'API plateforme.adresse.data.gouv.fr peut être en retard de plusieurs mois sur les sources de données.

La solution proposée dans cette PR est d'utiliser github actions pour lancer un build quotidien de l'application en utilisant l'API scalingo ([documentation](https://developers.scalingo.com/deployments#trigger-manually-a-deployment-from-a-github-repository)).

Trois points d'attention sont à noter : 
- scalingo fait de la mise en cache lors du build ([documentation](https://doc.scalingo.com/platform/deployment/cache)). Dans le cas de NodeJs, cette mise en cache ne concerne - à priori - que des modules installés
- le déploiement pourrait théoriquement être effectué directement depuis le build fait la CI. Ici afin de limiter la taille de la PR et de garder un comportement au plus proche de l'actuel, on envoie juste une notification à Scalingo qui va se charger de récupérer la dernière version de la branche master et effectuer un build depuis celle-ci
- pour que cette PR fonctionne il faut qu'un maintainer du repository ajoute un secret github action `SCALINGO_AUTHENTICATION_TOKEN` depuis `Settings > Secrets and variables > Actions > New repository secret`. Ce token est généré depuis scalingo par un utilisateur en allant dans ses paramètres de compte et en sélectionnant `API Tokens > Add`